### PR TITLE
README: Fix sample buildscript producing duplicate files in dev jars

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,6 @@ afterEvaluate {
 
 sourceSets {
     main {
-        output.resourcesDir = output.classesDir
         ext.refMap = refMapForYourConfig
     }
 }


### PR DESCRIPTION
The sample buildscript snippet in the readme makes the dev jars of mods contain two copies of every file. For reference, here's the standard snippet for generating dev jars:
```
task devJar(type: Jar) {
	classifier = 'dev'
	from sourceSets.main.output
}

artifacts {
	archives devJar
}
```
Removing the `output.resourcesDir = output.classesDir` line fixes this. Was there a reason for including it?